### PR TITLE
Add environment variable overrides for Hibernate settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ Esta app es una app de concepto y solo por fines de explorar diferentes tecnolog
 - Gradle
 - Neovim como editor tambien se puede correr en Vscode
 
+## Docker Compose
+
+El proyecto incluye un `docker-compose.yml` con un contenedor de Postgres para
+facilitar las pruebas locales. Para levantar la base de datos ejecuta:
+
+```bash
+docker-compose up -d
+```
+
+La configuración mínima para Hibernate se encuentra en
+`app/src/main/resources/hibernate.cfg.xml` y utiliza las credenciales definidas
+en el `docker-compose.yml`. Estos valores pueden sobrescribirse mediante las
+siguientes variables de entorno:
+
+- `HIBERNATE_CONN_URL`
+- `HIBERNATE_CONN_USERNAME`
+- `HIBERNATE_CONN_PASSWORD`
+- Opcionalmente `HIBERNATE_DIALECT` y `HIBERNATE_HBM2DDL_AUTO`.
+
 ## TODOs
 
 - [ ] Agregar versiones de todas las herramientas utilizadas

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,6 +19,8 @@ repositories {
 dependencies {
     // This dependency is used by the application.
     implementation(libs.guava)
+    implementation(libs.hibernate.core)
+    implementation(libs.postgresql)
 }
 
 testing {

--- a/app/src/main/java/com/oopecommerce/utils/HibernateUtil.java
+++ b/app/src/main/java/com/oopecommerce/utils/HibernateUtil.java
@@ -1,0 +1,33 @@
+package com.oopecommerce.utils;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.cfg.Configuration;
+
+public class HibernateUtil {
+    private static final SessionFactory sessionFactory = buildSessionFactory();
+
+    private static SessionFactory buildSessionFactory() {
+        try {
+            Configuration cfg = new Configuration().configure();
+            overrideProperty(cfg, "hibernate.connection.url", "HIBERNATE_CONN_URL");
+            overrideProperty(cfg, "hibernate.connection.username", "HIBERNATE_CONN_USERNAME");
+            overrideProperty(cfg, "hibernate.connection.password", "HIBERNATE_CONN_PASSWORD");
+            overrideProperty(cfg, "hibernate.dialect", "HIBERNATE_DIALECT");
+            overrideProperty(cfg, "hibernate.hbm2ddl.auto", "HIBERNATE_HBM2DDL_AUTO");
+            return cfg.buildSessionFactory();
+        } catch (Throwable ex) {
+            throw new ExceptionInInitializerError(ex);
+        }
+    }
+
+    private static void overrideProperty(Configuration cfg, String propertyName, String envVar) {
+        String value = System.getenv(envVar);
+        if (value != null && !value.isEmpty()) {
+            cfg.setProperty(propertyName, value);
+        }
+    }
+
+    public static SessionFactory getSessionFactory() {
+        return sessionFactory;
+    }
+}

--- a/app/src/main/resources/hibernate.cfg.xml
+++ b/app/src/main/resources/hibernate.cfg.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE hibernate-configuration PUBLIC
+        "-//Hibernate/Hibernate Configuration DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-configuration-3.0.dtd">
+<hibernate-configuration>
+    <session-factory>
+        <property name="hibernate.dialect">org.hibernate.dialect.PostgreSQLDialect</property>
+        <property name="hibernate.connection.driver_class">org.postgresql.Driver</property>
+        <property name="hibernate.connection.url">jdbc:postgresql://localhost:5432/oopecommerce</property>
+        <property name="hibernate.connection.username">oopecom</property>
+        <property name="hibernate.connection.password">secret</property>
+        <property name="hibernate.hbm2ddl.auto">update</property>
+        <!-- Estos valores pueden ser sobrescritos a traves de variables de entorno
+             revisadas en HibernateUtil -->
+    </session-factory>
+</hibernate-configuration>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  db:
+    image: postgres:15
+    restart: always
+    environment:
+      POSTGRES_DB: oopecommerce
+      POSTGRES_USER: oopecom
+      POSTGRES_PASSWORD: secret
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,10 @@
 
 [versions]
 guava = "33.4.5-jre"
+hibernate = "6.5.2.Final"
+postgres = "42.7.2"
 
 [libraries]
 guava = { module = "com.google.guava:guava", version.ref = "guava" }
+hibernate-core = { module = "org.hibernate.orm:hibernate-core", version.ref = "hibernate" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgres" }


### PR DESCRIPTION
## Summary
- allow overriding Hibernate connection properties using environment variables
- document the variables in the README
- note environment overrides in hibernate.cfg.xml

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68448702c1c883308255cd4edc7ae514