### PR TITLE
Add DESC sorting test and simplify SortableUtils test

### DIFF
--- a/app/src/test/java/test/oopecommerce/utils/sorts/TestSortableUtils.java
+++ b/app/src/test/java/test/oopecommerce/utils/sorts/TestSortableUtils.java
@@ -1,7 +1,7 @@
 package test.oopecommerce.utils.sorts;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,13 +43,17 @@ public class TestSortableUtils {
                 new TestClass(5));
 
         try {
-
             int[] value = SortableUtils.sortByPosition(items, SortDirection.ASC).stream()
-                    .mapToInt((v) -> v.getPosition()).toArray();
+                    .mapToInt(v -> v.getPosition()).toArray();
             int[] expectedValue = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             assertArrayEquals(expectedValue, value);
+
+            int[] descValue = SortableUtils.sortByPosition(items, SortDirection.DESC).stream()
+                    .mapToInt(v -> v.getPosition()).toArray();
+            int[] expectedDesc = { 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 };
+            assertArrayEquals(expectedDesc, descValue);
         } catch (Exception error) {
-            assertFalse("Error should not be throw", true);
+            fail("Error should not be thrown");
         }
 
     }


### PR DESCRIPTION
## Summary
- update `testSortableUtils` to fail on exceptions instead of asserting false
- verify results for both ASC and DESC sorting

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68448938a86083309f488cd78f91ece5