### PR TITLE
Integrate Swagger UI and document health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,24 @@ Esta app es una app de concepto y solo por fines de explorar diferentes tecnolog
 - [ ] Agregar versiones de todas las herramientas utilizadas
 - [ ] Agregar mas descripciones sobre las funcionalidades
 - [ ] Posiblemente descope algunas de las cosas que quiero hacer porque aparentamente me puedo ir lejos agregando cosas
+
+### Endpoints
+
+La aplicación cuenta con un endpoint básico de revisión de salud:
+
+```
+GET /checkhealth
+```
+
+que devuelve `{ "status": "ok" }`.
+
+### Documentación Swagger
+
+Se ha integrado `springdoc-openapi` para generar documentación automática.
+
+Al ejecutar la aplicación con Spring Boot, la documentación se puede visitar en:
+
+```
+http://localhost:8080/swagger-ui.html
+```
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,8 @@
  */
 
 plugins {
-    // Apply the application plugin to add support for building a CLI application in Java.
+    id("org.springframework.boot") version "3.2.5"
+    id("io.spring.dependency-management") version "1.1.4"
     application
 }
 
@@ -17,18 +18,13 @@ repositories {
 }
 
 dependencies {
-    // This dependency is used by the application.
-    implementation(libs.guava)
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
 }
 
-testing {
-    suites {
-        // Configure the built-in test suite
-        val test by getting(JvmTestSuite::class) {
-            // Use JUnit4 test framework
-            useJUnit("4.13.2")
-        }
-    }
+tasks.test {
+    useJUnitPlatform()
 }
 
 // Apply a specific Java toolchain to ease working on different environments.
@@ -39,6 +35,5 @@ java {
 }
 
 application {
-    // Define the main class for the application.
-    mainClass = "com.oopecommerce"
+    mainClass.set("com.oopecommerce.OopEcommerceApplication")
 }

--- a/app/src/main/java/com/oopecommerce/OopEcommerceApplication.java
+++ b/app/src/main/java/com/oopecommerce/OopEcommerceApplication.java
@@ -1,0 +1,11 @@
+package com.oopecommerce;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OopEcommerceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(OopEcommerceApplication.class, args);
+    }
+}

--- a/app/src/main/java/com/oopecommerce/api/HealthController.java
+++ b/app/src/main/java/com/oopecommerce/api/HealthController.java
@@ -1,0 +1,14 @@
+package com.oopecommerce.api;
+
+import java.util.Map;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+    @GetMapping("/checkhealth")
+    public Map<String, String> checkHealth() {
+        return Map.of("status", "ok");
+    }
+}

--- a/app/src/test/java/test/oopecommerce/AppTest.java
+++ b/app/src/test/java/test/oopecommerce/AppTest.java
@@ -3,15 +3,15 @@
  */
 package test.oopecommerce;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.oopecommerce.App;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class AppTest {
     @Test public void appHasAGreeting() {
         App classUnderTest = new App();
-        assertNotNull("app should have a greeting", classUnderTest.getGreeting());
+        assertNotNull(classUnderTest.getGreeting(), "app should have a greeting");
     }
 }

--- a/app/src/test/java/test/oopecommerce/api/HealthControllerTest.java
+++ b/app/src/test/java/test/oopecommerce/api/HealthControllerTest.java
@@ -1,0 +1,28 @@
+package test.oopecommerce.api;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest(classes = com.oopecommerce.OopEcommerceApplication.class)
+@AutoConfigureMockMvc
+public class HealthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    public void checkHealthReturnsOk() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/checkhealth"))
+            .andExpect(MockMvcResultMatchers.status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+        assertEquals("{\"status\":\"ok\"}", response);
+    }
+}

--- a/app/src/test/java/test/oopecommerce/models/carts/TestCart.java
+++ b/app/src/test/java/test/oopecommerce/models/carts/TestCart.java
@@ -1,13 +1,13 @@
 package test.oopecommerce.models.carts;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.oopecommerce.models.carts.Cart;
 import com.oopecommerce.models.inventory.InventoryLocation;

--- a/app/src/test/java/test/oopecommerce/models/carts/TestCartLineItem.java
+++ b/app/src/test/java/test/oopecommerce/models/carts/TestCartLineItem.java
@@ -1,10 +1,10 @@
 package test.oopecommerce.models.carts;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.oopecommerce.models.carts.CartLineItem;
 import com.oopecommerce.models.products.ProductVariant;

--- a/app/src/test/java/test/oopecommerce/models/inventory/TestInventoryLocation.java
+++ b/app/src/test/java/test/oopecommerce/models/inventory/TestInventoryLocation.java
@@ -1,7 +1,7 @@
 package test.oopecommerce.models.inventory;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import com.oopecommerce.models.inventory.InventoryLocation;
 
 public class TestInventoryLocation {

--- a/app/src/test/java/test/oopecommerce/models/products/TestDigitalProduct.java
+++ b/app/src/test/java/test/oopecommerce/models/products/TestDigitalProduct.java
@@ -1,7 +1,7 @@
 package test.oopecommerce.models.products;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import java.util.UUID;
 import com.oopecommerce.models.products.DigitalProduct;
 import com.oopecommerce.models.products.Product;

--- a/app/src/test/java/test/oopecommerce/models/products/TestPhysicalProduct.java
+++ b/app/src/test/java/test/oopecommerce/models/products/TestPhysicalProduct.java
@@ -1,7 +1,7 @@
 package test.oopecommerce.models.products;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import java.util.UUID;
 import com.oopecommerce.models.inventory.InventoryLocation;
 import com.oopecommerce.models.products.PhysicalProduct;

--- a/app/src/test/java/test/oopecommerce/models/products/TestProduct.java
+++ b/app/src/test/java/test/oopecommerce/models/products/TestProduct.java
@@ -1,12 +1,12 @@
 package test.oopecommerce.models.products;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.oopecommerce.models.inventory.InventoryLocation;
 import com.oopecommerce.models.products.PhysicalProduct;
@@ -70,13 +70,17 @@ public class TestProduct {
                 assertArrayEquals(expectedValue, value);
         }
 
-        @Test(expected = IllegalArgumentException.class)
+        @Test
         public void testProductVariantNegativePrice() {
-                new ProductVariant(UUID.randomUUID(), "SKU-NEG", null, 0, null, -10.0, "100");
+                assertThrows(IllegalArgumentException.class, () -> {
+                        new ProductVariant(UUID.randomUUID(), "SKU-NEG", null, 0, null, -10.0, "100");
+                });
         }
 
-        @Test(expected = IllegalArgumentException.class)
+        @Test
         public void testProductVariantNegativePosition() {
-                new ProductVariant(UUID.randomUUID(), "SKU-NEG", null, -1, null, 10.0, "100");
+                assertThrows(IllegalArgumentException.class, () -> {
+                        new ProductVariant(UUID.randomUUID(), "SKU-NEG", null, -1, null, 10.0, "100");
+                });
         }
 }

--- a/app/src/test/java/test/oopecommerce/models/products/TestProductMedia.java
+++ b/app/src/test/java/test/oopecommerce/models/products/TestProductMedia.java
@@ -1,11 +1,11 @@
 package test.oopecommerce.models.products;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.oopecommerce.models.products.ProductMedia;
 

--- a/app/src/test/java/test/oopecommerce/models/products/TestProductVariant.java
+++ b/app/src/test/java/test/oopecommerce/models/products/TestProductVariant.java
@@ -1,11 +1,11 @@
 package test.oopecommerce.models.products;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.oopecommerce.models.products.ProductVariant;
 

--- a/app/src/test/java/test/oopecommerce/models/users/TestAdmin.java
+++ b/app/src/test/java/test/oopecommerce/models/users/TestAdmin.java
@@ -1,7 +1,7 @@
 package test.oopecommerce.models.users;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import java.util.UUID;
 import com.oopecommerce.models.users.Admin;
 import com.oopecommerce.models.products.Product;
@@ -15,12 +15,12 @@ public class TestAdmin {
     private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
     private final PrintStream originalOut = System.out;
 
-    @org.junit.Before
+    @org.junit.jupiter.api.BeforeEach
     public void setUpStreams() {
         System.setOut(new PrintStream(outContent));
     }
 
-    @org.junit.After
+    @org.junit.jupiter.api.AfterEach
     public void restoreStreams() {
         System.setOut(originalOut);
     }

--- a/app/src/test/java/test/oopecommerce/models/users/TestCustomer.java
+++ b/app/src/test/java/test/oopecommerce/models/users/TestCustomer.java
@@ -1,7 +1,7 @@
 package test.oopecommerce.models.users;
 
-import static org.junit.Assert.*;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.Test;
 import java.util.UUID;
 import java.util.Date;
 import java.util.concurrent.TimeUnit;
@@ -73,13 +73,17 @@ public class TestCustomer {
         assertEquals(1, customer.viewOrderHistory(Order.OrderStatus.PENDING).size());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUserInvalidEmail() {
-        new Customer(UUID.randomUUID(), "invalid-email", "pass", "Test User", "none");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Customer(UUID.randomUUID(), "invalid-email", "pass", "Test User", "none");
+        });
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUserEmptyName() {
-        new Customer(UUID.randomUUID(), "valid@email.com", "pass", "  ", "none");
+        assertThrows(IllegalArgumentException.class, () -> {
+            new Customer(UUID.randomUUID(), "valid@email.com", "pass", "  ", "none");
+        });
     }
-} 
+}

--- a/app/src/test/java/test/oopecommerce/models/users/TestUser.java
+++ b/app/src/test/java/test/oopecommerce/models/users/TestUser.java
@@ -1,10 +1,10 @@
 package test.oopecommerce.models.users;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.UUID;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.oopecommerce.models.users.User;
 

--- a/app/src/test/java/test/oopecommerce/utils/sorts/TestSortableUtils.java
+++ b/app/src/test/java/test/oopecommerce/utils/sorts/TestSortableUtils.java
@@ -1,12 +1,12 @@
 package test.oopecommerce.utils.sorts;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import com.oopecommerce.utils.sorts.ISortable;
 import com.oopecommerce.utils.sorts.SortDirection;
@@ -49,7 +49,7 @@ public class TestSortableUtils {
             int[] expectedValue = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             assertArrayEquals(expectedValue, value);
         } catch (Exception error) {
-            assertFalse("Error should not be throw", true);
+            fail("Error should not be throw");
         }
 
     }


### PR DESCRIPTION
## Summary
- configure Spring Boot and springdoc in the build
- add `OopEcommerceApplication` and new `/checkhealth` controller
- document the new endpoint and Swagger UI in the README

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: no output produced)*

------
https://chatgpt.com/codex/tasks/task_e_6844872cfd348330a7beeb2f19cf9d96