### PR TITLE
Add request scoped logging

### DIFF
--- a/app/src/main/java/com/oopecommerce/api/HealthController.java
+++ b/app/src/main/java/com/oopecommerce/api/HealthController.java
@@ -2,13 +2,21 @@ package com.oopecommerce.api;
 
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.oopecommerce.utils.logging.RequestLogger;
+
 @RestController
 public class HealthController {
+
+    @Autowired
+    private RequestLogger logger;
+
     @GetMapping("/checkhealth")
     public Map<String, String> checkHealth() {
+        logger.info("Health check endpoint reached");
         return Map.of("status", "ok");
     }
 }

--- a/app/src/main/java/com/oopecommerce/utils/logging/RequestLogger.java
+++ b/app/src/main/java/com/oopecommerce/utils/logging/RequestLogger.java
@@ -1,0 +1,44 @@
+package com.oopecommerce.utils.logging;
+
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@RequestScope
+@Component
+public class RequestLogger {
+    private final Logger logger = LoggerFactory.getLogger(RequestLogger.class);
+    private final String requestId;
+    private final String operationName;
+
+    @Autowired
+    public RequestLogger(HttpServletRequest request) {
+        this.requestId = UUID.randomUUID().toString();
+        this.operationName = request.getMethod() + " " + request.getRequestURI();
+        MDC.put("requestId", this.requestId);
+        MDC.put("operationName", this.operationName);
+    }
+
+    public void info(String message) {
+        logger.info(message);
+    }
+
+    public void error(String message) {
+        logger.error(message);
+    }
+
+    public String getRequestId() {
+        return requestId;
+    }
+
+    public String getOperationName() {
+        return operationName;
+    }
+}

--- a/app/src/main/java/com/oopecommerce/utils/logging/RequestLoggingFilter.java
+++ b/app/src/main/java/com/oopecommerce/utils/logging/RequestLoggingFilter.java
@@ -1,0 +1,32 @@
+package com.oopecommerce.utils.logging;
+
+import java.io.IOException;
+
+import org.slf4j.MDC;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class RequestLoggingFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private RequestLogger requestLogger;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            requestLogger.info("Start handling request");
+            filterChain.doFilter(request, response);
+        } finally {
+            requestLogger.info("Finished handling request");
+            MDC.clear();
+        }
+    }
+}

--- a/app/src/main/resources/logback-spring.xml
+++ b/app/src/main/resources/logback-spring.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <property name="CONSOLE_LOG_PATTERN" value="%d{yyyy-MM-dd HH:mm:ss} %-5level [requestId:%X{requestId}] [operation:%X{operationName}] %logger{36} - %msg%n"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${CONSOLE_LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary
- add `RequestLogger` component with request-scoped fields
- log request lifecycle with `RequestLoggingFilter`
- inject logger into `HealthController`
- configure logback to include request and operation info

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68449bfca0808330be4821afae21782e