### PR TITLE
Implement notification observer

### DIFF
--- a/app/src/main/java/com/oopecommerce/models/orders/Order.java
+++ b/app/src/main/java/com/oopecommerce/models/orders/Order.java
@@ -3,6 +3,9 @@ package com.oopecommerce.models.orders;
 import java.util.Date;
 import java.util.UUID;
 import com.oopecommerce.models.addresses.ShippingAddress;
+import com.oopecommerce.notifications.EventManager;
+import com.oopecommerce.notifications.EventType;
+import com.oopecommerce.notifications.OrderStatusChangeEvent;
 
 public class Order {
     public enum OrderStatus {
@@ -48,7 +51,13 @@ public class Order {
     }
 
     public void setStatus(OrderStatus status) {
-        this.status = status;
+        if (this.status != status) {
+            OrderStatus previous = this.status;
+            this.status = status;
+            EventManager.getInstance().notify(
+                EventType.ORDER_STATUS_CHANGED,
+                new OrderStatusChangeEvent(this, previous, status));
+        }
     }
 
     public ShippingAddress getShippingAddress() {

--- a/app/src/main/java/com/oopecommerce/notifications/EventManager.java
+++ b/app/src/main/java/com/oopecommerce/notifications/EventManager.java
@@ -1,0 +1,38 @@
+package com.oopecommerce.notifications;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+public class EventManager {
+    private static final EventManager instance = new EventManager();
+    private final Map<EventType, List<NotificationObserver>> observers = new EnumMap<>(EventType.class);
+
+    private EventManager() {}
+
+    public static EventManager getInstance() {
+        return instance;
+    }
+
+    public void subscribe(EventType type, NotificationObserver observer) {
+        observers.computeIfAbsent(type, k -> new ArrayList<>()).add(observer);
+    }
+
+    public void unsubscribe(EventType type, NotificationObserver observer) {
+        List<NotificationObserver> list = observers.get(type);
+        if (list != null) {
+            list.remove(observer);
+        }
+    }
+
+    public void notify(EventType type, NotificationEvent event) {
+        List<NotificationObserver> list = observers.get(type);
+        if (list != null) {
+            // clone the list to avoid ConcurrentModificationException
+            for (NotificationObserver ob : new ArrayList<>(list)) {
+                ob.update(event);
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/oopecommerce/notifications/EventType.java
+++ b/app/src/main/java/com/oopecommerce/notifications/EventType.java
@@ -1,0 +1,5 @@
+package com.oopecommerce.notifications;
+
+public enum EventType {
+    ORDER_STATUS_CHANGED
+}

--- a/app/src/main/java/com/oopecommerce/notifications/NotificationEvent.java
+++ b/app/src/main/java/com/oopecommerce/notifications/NotificationEvent.java
@@ -1,0 +1,4 @@
+package com.oopecommerce.notifications;
+
+public interface NotificationEvent {
+}

--- a/app/src/main/java/com/oopecommerce/notifications/NotificationObserver.java
+++ b/app/src/main/java/com/oopecommerce/notifications/NotificationObserver.java
@@ -1,0 +1,5 @@
+package com.oopecommerce.notifications;
+
+public interface NotificationObserver {
+    void update(NotificationEvent event);
+}

--- a/app/src/main/java/com/oopecommerce/notifications/OrderStatusChangeEvent.java
+++ b/app/src/main/java/com/oopecommerce/notifications/OrderStatusChangeEvent.java
@@ -1,0 +1,28 @@
+package com.oopecommerce.notifications;
+
+import com.oopecommerce.models.orders.Order;
+import com.oopecommerce.models.orders.Order.OrderStatus;
+
+public class OrderStatusChangeEvent implements NotificationEvent {
+    private final Order order;
+    private final OrderStatus oldStatus;
+    private final OrderStatus newStatus;
+
+    public OrderStatusChangeEvent(Order order, OrderStatus oldStatus, OrderStatus newStatus) {
+        this.order = order;
+        this.oldStatus = oldStatus;
+        this.newStatus = newStatus;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public OrderStatus getOldStatus() {
+        return oldStatus;
+    }
+
+    public OrderStatus getNewStatus() {
+        return newStatus;
+    }
+}

--- a/app/src/test/java/test/oopecommerce/models/orders/TestOrderNotifications.java
+++ b/app/src/test/java/test/oopecommerce/models/orders/TestOrderNotifications.java
@@ -1,0 +1,47 @@
+package test.oopecommerce.models.orders;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.oopecommerce.models.addresses.ShippingAddress;
+import com.oopecommerce.models.orders.Order;
+import com.oopecommerce.models.orders.Order.OrderStatus;
+import com.oopecommerce.notifications.*;
+
+class TestObserver implements NotificationObserver {
+    List<NotificationEvent> events = new ArrayList<>();
+
+    @Override
+    public void update(NotificationEvent event) {
+        events.add(event);
+    }
+}
+
+public class TestOrderNotifications {
+
+    @Test
+    public void observerReceivesStatusChangeEvent() {
+        ShippingAddress address = new ShippingAddress("street", "city", "state", "zip", "country");
+        Order order = new Order(address);
+
+        TestObserver observer = new TestObserver();
+        EventManager manager = EventManager.getInstance();
+        manager.subscribe(EventType.ORDER_STATUS_CHANGED, observer);
+
+        order.setStatus(OrderStatus.SHIPPED);
+
+        assertEquals(1, observer.events.size());
+        NotificationEvent evt = observer.events.get(0);
+        assertTrue(evt instanceof OrderStatusChangeEvent);
+        OrderStatusChangeEvent event = (OrderStatusChangeEvent) evt;
+        assertEquals(order, event.getOrder());
+        assertEquals(OrderStatus.PENDING, event.getOldStatus());
+        assertEquals(OrderStatus.SHIPPED, event.getNewStatus());
+
+        manager.unsubscribe(EventType.ORDER_STATUS_CHANGED, observer);
+    }
+}


### PR DESCRIPTION
## Summary
- add a generic observer framework under `notifications`
- fire an `ORDER_STATUS_CHANGED` event when an order status is updated
- test that observers receive order status change notifications

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684c7e7275a88330a19335a7c4131d63