### PR TITLE
Add observer for order status changes

### DIFF
--- a/app/src/main/java/com/oopecommerce/models/orders/Order.java
+++ b/app/src/main/java/com/oopecommerce/models/orders/Order.java
@@ -3,6 +3,7 @@ package com.oopecommerce.models.orders;
 import java.util.Date;
 import java.util.UUID;
 import com.oopecommerce.models.addresses.ShippingAddress;
+import com.oopecommerce.models.orders.OrderStatusNotifier;
 
 public class Order {
     public enum OrderStatus {
@@ -48,7 +49,11 @@ public class Order {
     }
 
     public void setStatus(OrderStatus status) {
-        this.status = status;
+        if (this.status != status) {
+            OrderStatus oldStatus = this.status;
+            this.status = status;
+            OrderStatusNotifier.getInstance().notifyStatusChange(this, oldStatus, status);
+        }
     }
 
     public ShippingAddress getShippingAddress() {

--- a/app/src/main/java/com/oopecommerce/models/orders/OrderStatusChangeEvent.java
+++ b/app/src/main/java/com/oopecommerce/models/orders/OrderStatusChangeEvent.java
@@ -1,0 +1,25 @@
+package com.oopecommerce.models.orders;
+
+public class OrderStatusChangeEvent {
+    private final Order order;
+    private final Order.OrderStatus oldStatus;
+    private final Order.OrderStatus newStatus;
+
+    public OrderStatusChangeEvent(Order order, Order.OrderStatus oldStatus, Order.OrderStatus newStatus) {
+        this.order = order;
+        this.oldStatus = oldStatus;
+        this.newStatus = newStatus;
+    }
+
+    public Order getOrder() {
+        return order;
+    }
+
+    public Order.OrderStatus getOldStatus() {
+        return oldStatus;
+    }
+
+    public Order.OrderStatus getNewStatus() {
+        return newStatus;
+    }
+}

--- a/app/src/main/java/com/oopecommerce/models/orders/OrderStatusNotifier.java
+++ b/app/src/main/java/com/oopecommerce/models/orders/OrderStatusNotifier.java
@@ -1,0 +1,18 @@
+package com.oopecommerce.models.orders;
+
+import com.oopecommerce.notifications.Observable;
+
+public class OrderStatusNotifier extends Observable<OrderStatusChangeEvent> {
+    private static final OrderStatusNotifier INSTANCE = new OrderStatusNotifier();
+
+    private OrderStatusNotifier() {
+    }
+
+    public static OrderStatusNotifier getInstance() {
+        return INSTANCE;
+    }
+
+    public void notifyStatusChange(Order order, Order.OrderStatus oldStatus, Order.OrderStatus newStatus) {
+        notifyObservers(new OrderStatusChangeEvent(order, oldStatus, newStatus));
+    }
+}

--- a/app/src/main/java/com/oopecommerce/notifications/Observable.java
+++ b/app/src/main/java/com/oopecommerce/notifications/Observable.java
@@ -1,0 +1,22 @@
+package com.oopecommerce.notifications;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Observable<T> {
+    private final List<Observer<T>> observers = new ArrayList<>();
+
+    public void subscribe(Observer<T> observer) {
+        observers.add(observer);
+    }
+
+    public void unsubscribe(Observer<T> observer) {
+        observers.remove(observer);
+    }
+
+    protected void notifyObservers(T event) {
+        for (Observer<T> observer : observers) {
+            observer.update(event);
+        }
+    }
+}

--- a/app/src/main/java/com/oopecommerce/notifications/Observer.java
+++ b/app/src/main/java/com/oopecommerce/notifications/Observer.java
@@ -1,0 +1,5 @@
+package com.oopecommerce.notifications;
+
+public interface Observer<T> {
+    void update(T event);
+}

--- a/app/src/test/java/test/oopecommerce/models/orders/TestOrderObserver.java
+++ b/app/src/test/java/test/oopecommerce/models/orders/TestOrderObserver.java
@@ -1,0 +1,35 @@
+package test.oopecommerce.models.orders;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import com.oopecommerce.models.addresses.ShippingAddress;
+import com.oopecommerce.models.orders.Order;
+import com.oopecommerce.models.orders.OrderStatusChangeEvent;
+import com.oopecommerce.models.orders.OrderStatusNotifier;
+import com.oopecommerce.notifications.Observer;
+
+public class TestOrderObserver {
+    @Test
+    public void observersAreNotifiedOnStatusChange() {
+        ShippingAddress address = new ShippingAddress("Street", "City", "State", "0000", "Country");
+        Order order = new Order(address);
+
+        AtomicReference<OrderStatusChangeEvent> received = new AtomicReference<>();
+        Observer<OrderStatusChangeEvent> observer = received::set;
+
+        OrderStatusNotifier notifier = OrderStatusNotifier.getInstance();
+        notifier.subscribe(observer);
+
+        order.setStatus(Order.OrderStatus.SHIPPED);
+
+        assertNotNull(received.get());
+        assertEquals(Order.OrderStatus.PENDING, received.get().getOldStatus());
+        assertEquals(Order.OrderStatus.SHIPPED, received.get().getNewStatus());
+
+        notifier.unsubscribe(observer);
+    }
+}


### PR DESCRIPTION
## Summary
- implement simple Observer and Observable utils
- create OrderStatusChangeEvent and OrderStatusNotifier
- update Order to publish notifications when status changes
- test order observer notification

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684c7e7275a88330a19335a7c4131d63