### PR TITLE
Add Hibernate entities for cart and payment

### DIFF
--- a/app/src/main/java/com/oopecommerce/models/addresses/ShippingAddress.java
+++ b/app/src/main/java/com/oopecommerce/models/addresses/ShippingAddress.java
@@ -1,20 +1,54 @@
 package com.oopecommerce.models.addresses;
 
 import java.util.Objects;
+import java.util.UUID;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "shipping_addresses")
 public class ShippingAddress {
+    @Id
+    @Column(name = "id", columnDefinition = "uuid")
+    private UUID id;
+
+    @Column(name = "street_address")
     private String streetAddress;
+
+    @Column(name = "city")
     private String city;
+
+    @Column(name = "state")
     private String state;
+
+    @Column(name = "zip_code")
     private String zipCode;
+
+    @Column(name = "country")
     private String country;
 
-    public ShippingAddress(String streetAddress, String city, String state, String zipCode, String country) {
+    protected ShippingAddress() {
+        // Required by Hibernate
+    }
+
+    public ShippingAddress(UUID id, String streetAddress, String city, String state, String zipCode, String country) {
+        this.id = id;
         this.streetAddress = streetAddress;
         this.city = city;
         this.state = state;
         this.zipCode = zipCode;
         this.country = country;
+    }
+
+    public ShippingAddress(String streetAddress, String city, String state, String zipCode, String country) {
+        this(UUID.randomUUID(), streetAddress, city, state, zipCode, country);
+    }
+
+    public UUID getId() {
+        return id;
     }
 
     // Getters and Setters

--- a/app/src/main/java/com/oopecommerce/models/carts/Cart.java
+++ b/app/src/main/java/com/oopecommerce/models/carts/Cart.java
@@ -10,12 +10,39 @@ import com.oopecommerce.models.users.User;
 import com.oopecommerce.models.products.Product;
 import com.oopecommerce.models.products.ProductVariant;
 
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "carts")
 public class Cart {
-    final UUID id;
-    List<CartLineItem> lineItems;
-    final User user;
-    final Date createdAt;
-    Date updatedAt;
+    @Id
+    @Column(name = "id", columnDefinition = "uuid")
+    private UUID id;
+
+    @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CartLineItem> lineItems;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    @Column(name = "updated_at")
+    private Date updatedAt;
+
+    protected Cart() {
+        // Required by Hibernate
+    }
 
     public Cart(User user) {
         this.id = UUID.randomUUID();
@@ -116,3 +143,4 @@ public class Cart {
         this.updatedAt = updatedAt;
     }
 }
+

--- a/app/src/main/java/com/oopecommerce/models/carts/CartLineItem.java
+++ b/app/src/main/java/com/oopecommerce/models/carts/CartLineItem.java
@@ -5,19 +5,56 @@ import java.util.UUID;
 
 import com.oopecommerce.models.products.ProductVariant;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "cart_line_items")
 public class CartLineItem {
-    final UUID id;
-    ProductVariant variant;
-    int quantity;
-    Date createdAt;
-    Date updatedAt;
+    @Id
+    @Column(name = "id", columnDefinition = "uuid")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "variant_id")
+    private ProductVariant variant;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cart_id")
+    private Cart cart;
+
+    @Column(name = "quantity")
+    private int quantity;
+
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    @Column(name = "updated_at")
+    private Date updatedAt;
+
+    protected CartLineItem() {
+        // Required by Hibernate
+    }
 
     public CartLineItem(UUID id, ProductVariant variant, int quantity, Date createdAt, Date updatedAt) {
-        this.id = id;
+        this.id = (id != null) ? id : UUID.randomUUID();
         this.variant = variant;
         this.quantity = quantity;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+    }
+
+    public void setCart(Cart cart) {
+        this.cart = cart;
+    }
+
+    public Cart getCart() {
+        return cart;
     }
 
     public double getTotal() {
@@ -64,3 +101,4 @@ public class CartLineItem {
         this.updatedAt = updatedAt;
     }
 }
+

--- a/app/src/main/java/com/oopecommerce/models/inventory/InventoryLocation.java
+++ b/app/src/main/java/com/oopecommerce/models/inventory/InventoryLocation.java
@@ -1,16 +1,49 @@
 package com.oopecommerce.models.inventory;
 
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "inventory_locations")
 public class InventoryLocation {
+    @Id
+    @Column(name = "id", columnDefinition = "uuid")
+    private UUID id;
+
+    @Column(name = "warehouse_code")
     private String warehouseCode;
+
+    @Column(name = "street_address")
     private String streetAddress;
+
+    @Column(name = "city")
     private String city;
+
+    @Column(name = "country")
     private String country;
 
-    public InventoryLocation(String warehouseCode, String streetAddress, String city, String country) {
+    protected InventoryLocation() {
+        // Required by Hibernate
+    }
+
+    public InventoryLocation(UUID id, String warehouseCode, String streetAddress, String city, String country) {
+        this.id = id;
         this.warehouseCode = warehouseCode;
         this.streetAddress = streetAddress;
         this.city = city;
         this.country = country;
+    }
+
+    public InventoryLocation(String warehouseCode, String streetAddress, String city, String country) {
+        this(UUID.randomUUID(), warehouseCode, streetAddress, city, country);
+    }
+
+    public UUID getId() {
+        return id;
     }
 
     public String getWarehouseCode() {

--- a/app/src/main/java/com/oopecommerce/models/payments/Payment.java
+++ b/app/src/main/java/com/oopecommerce/models/payments/Payment.java
@@ -1,0 +1,105 @@
+package com.oopecommerce.models.payments;
+
+import java.util.Date;
+import java.util.UUID;
+
+import com.oopecommerce.models.users.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "payments")
+public class Payment {
+    public enum Status {
+        SUCCESS,
+        FAILURE,
+        PENDING
+    }
+
+    @Id
+    @Column(name = "id", columnDefinition = "uuid")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(name = "amount")
+    private double amount;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private Status status;
+
+    @Column(name = "method")
+    private String method;
+
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    protected Payment() {
+        // Required by Hibernate
+    }
+
+    public Payment(UUID id, User user, double amount, Status status, String method, Date createdAt) {
+        this.id = id;
+        this.user = user;
+        this.amount = amount;
+        this.status = status;
+        this.method = method;
+        this.createdAt = createdAt;
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(double amount) {
+        this.amount = amount;
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public String getMethod() {
+        return method;
+    }
+
+    public void setMethod(String method) {
+        this.method = method;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+}
+

--- a/app/src/main/java/com/oopecommerce/utils/HibernateUtil.java
+++ b/app/src/main/java/com/oopecommerce/utils/HibernateUtil.java
@@ -33,6 +33,11 @@ public class HibernateUtil {
             cfg.addAnnotatedClass(com.oopecommerce.models.products.ProductMedia.class);
             cfg.addAnnotatedClass(com.oopecommerce.models.products.ProductVariant.class);
             cfg.addAnnotatedClass(com.oopecommerce.models.products.SimpleProduct.class);
+            cfg.addAnnotatedClass(com.oopecommerce.models.addresses.ShippingAddress.class);
+            cfg.addAnnotatedClass(com.oopecommerce.models.carts.Cart.class);
+            cfg.addAnnotatedClass(com.oopecommerce.models.carts.CartLineItem.class);
+            cfg.addAnnotatedClass(com.oopecommerce.models.inventory.InventoryLocation.class);
+            cfg.addAnnotatedClass(com.oopecommerce.models.payments.Payment.class);
             return cfg.buildSessionFactory();
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);

--- a/app/src/main/resources/db/migration/V3__create_cart_inventory_payment_tables.sql
+++ b/app/src/main/resources/db/migration/V3__create_cart_inventory_payment_tables.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS shipping_addresses (
+    id UUID PRIMARY KEY,
+    street_address VARCHAR(255) NOT NULL,
+    city VARCHAR(100) NOT NULL,
+    state VARCHAR(100),
+    zip_code VARCHAR(20),
+    country VARCHAR(100) NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS carts (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_carts_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS cart_line_items (
+    id UUID PRIMARY KEY,
+    cart_id UUID NOT NULL,
+    variant_id UUID NOT NULL,
+    quantity INT NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_line_item_cart FOREIGN KEY (cart_id) REFERENCES carts(id) ON DELETE CASCADE,
+    CONSTRAINT fk_line_item_variant FOREIGN KEY (variant_id) REFERENCES product_variants(id)
+);
+
+CREATE TABLE IF NOT EXISTS inventory_locations (
+    id UUID PRIMARY KEY,
+    warehouse_code VARCHAR(100) NOT NULL,
+    street_address VARCHAR(255),
+    city VARCHAR(100),
+    country VARCHAR(100)
+);
+
+CREATE TABLE IF NOT EXISTS payments (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    amount DOUBLE PRECISION NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    method VARCHAR(50),
+    created_at TIMESTAMP NOT NULL,
+    CONSTRAINT fk_payments_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+

--- a/app/src/test/java/test/oopecommerce/utils/HibernateTestUtil.java
+++ b/app/src/test/java/test/oopecommerce/utils/HibernateTestUtil.java
@@ -26,6 +26,11 @@ public class HibernateTestUtil {
         cfg.addAnnotatedClass(com.oopecommerce.models.products.ProductMedia.class);
         cfg.addAnnotatedClass(com.oopecommerce.models.products.ProductVariant.class);
         cfg.addAnnotatedClass(com.oopecommerce.models.products.SimpleProduct.class);
+        cfg.addAnnotatedClass(com.oopecommerce.models.addresses.ShippingAddress.class);
+        cfg.addAnnotatedClass(com.oopecommerce.models.carts.Cart.class);
+        cfg.addAnnotatedClass(com.oopecommerce.models.carts.CartLineItem.class);
+        cfg.addAnnotatedClass(com.oopecommerce.models.inventory.InventoryLocation.class);
+        cfg.addAnnotatedClass(com.oopecommerce.models.payments.Payment.class);
         return cfg.buildSessionFactory();
     }
 }


### PR DESCRIPTION
## Summary
- map `ShippingAddress`, `Cart`, `CartLineItem`, and `InventoryLocation` as JPA entities
- introduce `Payment` entity
- register new entities in `HibernateUtil` and test configuration
- create migration for address, cart, inventory and payment tables

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_684c81f63aa48330820c7052e6aae4f4