### PR TITLE
Add InventoryLevel model and API

### DIFF
--- a/app/src/main/java/com/oopecommerce/api/InventoryLevelController.java
+++ b/app/src/main/java/com/oopecommerce/api/InventoryLevelController.java
@@ -1,0 +1,96 @@
+package com.oopecommerce.api;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.google.gson.Gson;
+import com.oopecommerce.dto.inventory.InventoryLevelDTO;
+import com.oopecommerce.dto.inventory.UpdateInventoryLevelInput;
+import com.oopecommerce.models.inventory.InventoryLevel;
+import com.oopecommerce.models.inventory.InventoryLocation;
+import com.oopecommerce.models.products.Product;
+import com.oopecommerce.repositories.InventoryLevelRepository;
+import com.oopecommerce.repositories.ProductRepository;
+import com.oopecommerce.repositories.InventoryLocationRepository;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/products/{productId}/locations")
+public class InventoryLevelController {
+    private final Gson gson = new Gson();
+    private final InventoryLevelRepository repository;
+    private final ProductRepository productRepository;
+    private final InventoryLocationRepository locationRepository;
+
+    public InventoryLevelController(InventoryLevelRepository repository, ProductRepository productRepository,
+            InventoryLocationRepository locationRepository) {
+        this.repository = repository;
+        this.productRepository = productRepository;
+        this.locationRepository = locationRepository;
+    }
+
+    private InventoryLevelDTO toDto(InventoryLevel level) {
+        return new InventoryLevelDTO(level.getId(), level.getProduct().getId(), level.getLocation().getId(), level.getQuantity());
+    }
+
+    @GetMapping(value = "", produces = MediaType.APPLICATION_JSON_VALUE)
+    public String listLevels(@PathVariable UUID productId) {
+        Iterable<InventoryLevel> list = repository.findAllByProduct(productId);
+        List<InventoryLevelDTO> out = new ArrayList<>();
+        list.forEach(l -> out.add(toDto(l)));
+        return gson.toJson(out);
+    }
+
+    @GetMapping(value = "/{locationId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<String> getLevel(@PathVariable UUID productId, @PathVariable UUID locationId) {
+        var level = repository.findByProductAndLocation(productId, locationId).orElse(null);
+        if (level == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(gson.toJson(toDto(level)));
+    }
+
+    @PutMapping(value = "/{locationId}")
+    public ResponseEntity<String> setLevel(@PathVariable UUID productId, @PathVariable UUID locationId,
+            @Valid @RequestBody UpdateInventoryLevelInput req) {
+        Product product = productRepository.findById(productId).orElse(null);
+        if (product == null) {
+            return ResponseEntity.notFound().build();
+        }
+        InventoryLocation loc = locationRepository.findById(locationId).orElse(null);
+        if (loc == null) {
+            return ResponseEntity.notFound().build();
+        }
+        InventoryLevel level = repository.findByProductAndLocation(productId, locationId).orElse(null);
+        if (level == null) {
+            level = new InventoryLevel(UUID.randomUUID(), product, loc, req.getQuantity());
+        } else {
+            level.setQuantity(req.getQuantity());
+        }
+        repository.save(level);
+        return ResponseEntity.status(HttpStatus.OK).contentType(MediaType.APPLICATION_JSON).body(gson.toJson(toDto(level)));
+    }
+
+    @DeleteMapping(value = "/{locationId}")
+    public ResponseEntity<Void> deleteLevel(@PathVariable UUID productId, @PathVariable UUID locationId) {
+        InventoryLevel level = repository.findByProductAndLocation(productId, locationId).orElse(null);
+        if (level == null) {
+            return ResponseEntity.notFound().build();
+        }
+        repository.delete(level.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/app/src/main/java/com/oopecommerce/dto/inventory/InventoryLevelDTO.java
+++ b/app/src/main/java/com/oopecommerce/dto/inventory/InventoryLevelDTO.java
@@ -1,0 +1,31 @@
+package com.oopecommerce.dto.inventory;
+
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Quantity of a product stored at a specific location")
+public class InventoryLevelDTO {
+    private UUID id;
+    private UUID productId;
+    private UUID locationId;
+    private int quantity;
+
+    public InventoryLevelDTO() {}
+
+    public InventoryLevelDTO(UUID id, UUID productId, UUID locationId, int quantity) {
+        this.id = id;
+        this.productId = productId;
+        this.locationId = locationId;
+        this.quantity = quantity;
+    }
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public UUID getProductId() { return productId; }
+    public void setProductId(UUID productId) { this.productId = productId; }
+    public UUID getLocationId() { return locationId; }
+    public void setLocationId(UUID locationId) { this.locationId = locationId; }
+    public int getQuantity() { return quantity; }
+    public void setQuantity(int quantity) { this.quantity = quantity; }
+}

--- a/app/src/main/java/com/oopecommerce/dto/inventory/UpdateInventoryLevelInput.java
+++ b/app/src/main/java/com/oopecommerce/dto/inventory/UpdateInventoryLevelInput.java
@@ -1,0 +1,19 @@
+package com.oopecommerce.dto.inventory;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+
+@Schema(description = "Information required to set inventory quantity")
+public class UpdateInventoryLevelInput {
+    @Min(0)
+    private int quantity;
+
+    public UpdateInventoryLevelInput() {}
+
+    public UpdateInventoryLevelInput(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public int getQuantity() { return quantity; }
+    public void setQuantity(int quantity) { this.quantity = quantity; }
+}

--- a/app/src/main/java/com/oopecommerce/models/inventory/InventoryLevel.java
+++ b/app/src/main/java/com/oopecommerce/models/inventory/InventoryLevel.java
@@ -1,0 +1,75 @@
+package com.oopecommerce.models.inventory;
+
+import java.util.UUID;
+
+import com.oopecommerce.models.products.Product;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "inventory_levels")
+public class InventoryLevel {
+    @Id
+    @Column(name = "id", columnDefinition = "uuid")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", nullable = false)
+    private InventoryLocation location;
+
+    @Column(name = "quantity", nullable = false)
+    private int quantity;
+
+    protected InventoryLevel() {
+        // Required by Hibernate
+    }
+
+    public InventoryLevel(UUID id, Product product, InventoryLocation location, int quantity) {
+        this.id = id;
+        this.product = product;
+        this.location = location;
+        this.quantity = quantity;
+    }
+
+    public InventoryLevel(Product product, InventoryLocation location, int quantity) {
+        this(UUID.randomUUID(), product, location, quantity);
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public Product getProduct() {
+        return product;
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
+
+    public InventoryLocation getLocation() {
+        return location;
+    }
+
+    public void setLocation(InventoryLocation location) {
+        this.location = location;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/app/src/main/java/com/oopecommerce/models/inventory/InventoryLocation.java
+++ b/app/src/main/java/com/oopecommerce/models/inventory/InventoryLocation.java
@@ -46,6 +46,10 @@ public class InventoryLocation {
         return id;
     }
 
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
     public String getWarehouseCode() {
         return warehouseCode;
     }

--- a/app/src/main/java/com/oopecommerce/repositories/HibernateInventoryLevelRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/HibernateInventoryLevelRepository.java
@@ -1,0 +1,65 @@
+package com.oopecommerce.repositories;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+
+import com.oopecommerce.models.inventory.InventoryLevel;
+import com.oopecommerce.utils.HibernateUtil;
+
+public class HibernateInventoryLevelRepository implements InventoryLevelRepository {
+    private final SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+
+    @Override
+    public Optional<InventoryLevel> findById(UUID id) {
+        try (Session session = sessionFactory.openSession()) {
+            return Optional.ofNullable(session.get(InventoryLevel.class, id));
+        }
+    }
+
+    @Override
+    public Optional<InventoryLevel> findByProductAndLocation(UUID productId, UUID locationId) {
+        try (Session session = sessionFactory.openSession()) {
+            String hql = "from InventoryLevel where product.id = :pid and location.id = :lid";
+            InventoryLevel level = session.createQuery(hql, InventoryLevel.class)
+                    .setParameter("pid", productId)
+                    .setParameter("lid", locationId)
+                    .uniqueResult();
+            return Optional.ofNullable(level);
+        }
+    }
+
+    @Override
+    public void save(InventoryLevel level) {
+        try (Session session = sessionFactory.openSession()) {
+            Transaction tx = session.beginTransaction();
+            session.merge(level);
+            tx.commit();
+        }
+    }
+
+    @Override
+    public void delete(UUID id) {
+        try (Session session = sessionFactory.openSession()) {
+            Transaction tx = session.beginTransaction();
+            InventoryLevel l = session.get(InventoryLevel.class, id);
+            if (l != null) session.remove(l);
+            tx.commit();
+        }
+    }
+
+    @Override
+    public Iterable<InventoryLevel> findAllByProduct(UUID productId) {
+        try (Session session = sessionFactory.openSession()) {
+            String hql = "from InventoryLevel where product.id = :pid";
+            List<InventoryLevel> list = session.createQuery(hql, InventoryLevel.class)
+                    .setParameter("pid", productId)
+                    .list();
+            return list;
+        }
+    }
+}

--- a/app/src/main/java/com/oopecommerce/repositories/HibernateInventoryLocationRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/HibernateInventoryLocationRepository.java
@@ -1,0 +1,30 @@
+package com.oopecommerce.repositories;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+
+import com.oopecommerce.models.inventory.InventoryLocation;
+import com.oopecommerce.utils.HibernateUtil;
+
+public class HibernateInventoryLocationRepository implements InventoryLocationRepository {
+    private final SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
+
+    @Override
+    public Optional<InventoryLocation> findById(UUID id) {
+        try (Session session = sessionFactory.openSession()) {
+            return Optional.ofNullable(session.get(InventoryLocation.class, id));
+        }
+    }
+
+    @Override
+    public Iterable<InventoryLocation> findAll() {
+        try (Session session = sessionFactory.openSession()) {
+            List<InventoryLocation> list = session.createQuery("from InventoryLocation", InventoryLocation.class).list();
+            return list;
+        }
+    }
+}

--- a/app/src/main/java/com/oopecommerce/repositories/InMemoryInventoryLevelRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/InMemoryInventoryLevelRepository.java
@@ -1,0 +1,46 @@
+package com.oopecommerce.repositories;
+
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+import com.oopecommerce.models.inventory.InventoryLevel;
+
+@Component
+public class InMemoryInventoryLevelRepository implements InventoryLevelRepository {
+    private final Map<UUID, InventoryLevel> levels = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<InventoryLevel> findById(UUID id) {
+        return Optional.ofNullable(levels.get(id));
+    }
+
+    @Override
+    public Optional<InventoryLevel> findByProductAndLocation(UUID productId, UUID locationId) {
+        return levels.values().stream()
+            .filter(l -> l.getProduct().getId().equals(productId) && l.getLocation().getId().equals(locationId))
+            .findFirst();
+    }
+
+    @Override
+    public void save(InventoryLevel level) {
+        levels.put(level.getId(), level);
+    }
+
+    @Override
+    public void delete(UUID id) {
+        levels.remove(id);
+    }
+
+    @Override
+    public Iterable<InventoryLevel> findAllByProduct(UUID productId) {
+        List<InventoryLevel> list = new ArrayList<>();
+        levels.values().forEach(l -> { if (l.getProduct().getId().equals(productId)) list.add(l); });
+        return list;
+    }
+}

--- a/app/src/main/java/com/oopecommerce/repositories/InMemoryInventoryLocationRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/InMemoryInventoryLocationRepository.java
@@ -1,0 +1,31 @@
+package com.oopecommerce.repositories;
+
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+import com.oopecommerce.models.inventory.InventoryLocation;
+
+@Component
+public class InMemoryInventoryLocationRepository implements InventoryLocationRepository {
+    private final Map<UUID, InventoryLocation> locations = new ConcurrentHashMap<>();
+
+    @Override
+    public Optional<InventoryLocation> findById(UUID id) {
+        return Optional.ofNullable(locations.get(id));
+    }
+
+    @Override
+    public Iterable<InventoryLocation> findAll() {
+        return new ArrayList<>(locations.values());
+    }
+
+    public void save(InventoryLocation loc) {
+        locations.put(loc.getId(), loc);
+    }
+}

--- a/app/src/main/java/com/oopecommerce/repositories/InventoryLevelRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/InventoryLevelRepository.java
@@ -1,0 +1,14 @@
+package com.oopecommerce.repositories;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.oopecommerce.models.inventory.InventoryLevel;
+
+public interface InventoryLevelRepository {
+    Optional<InventoryLevel> findById(UUID id);
+    Optional<InventoryLevel> findByProductAndLocation(UUID productId, UUID locationId);
+    void save(InventoryLevel level);
+    void delete(UUID id);
+    Iterable<InventoryLevel> findAllByProduct(UUID productId);
+}

--- a/app/src/main/java/com/oopecommerce/repositories/InventoryLocationRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/InventoryLocationRepository.java
@@ -1,0 +1,11 @@
+package com.oopecommerce.repositories;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import com.oopecommerce.models.inventory.InventoryLocation;
+
+public interface InventoryLocationRepository {
+    Optional<InventoryLocation> findById(UUID id);
+    Iterable<InventoryLocation> findAll();
+}

--- a/app/src/main/java/com/oopecommerce/utils/HibernateUtil.java
+++ b/app/src/main/java/com/oopecommerce/utils/HibernateUtil.java
@@ -37,6 +37,7 @@ public class HibernateUtil {
             cfg.addAnnotatedClass(com.oopecommerce.models.carts.Cart.class);
             cfg.addAnnotatedClass(com.oopecommerce.models.carts.CartLineItem.class);
             cfg.addAnnotatedClass(com.oopecommerce.models.inventory.InventoryLocation.class);
+            cfg.addAnnotatedClass(com.oopecommerce.models.inventory.InventoryLevel.class);
             cfg.addAnnotatedClass(com.oopecommerce.models.payments.Payment.class);
             return cfg.buildSessionFactory();
         } catch (Throwable ex) {

--- a/app/src/main/resources/db/migration/V4__create_inventory_levels_table.sql
+++ b/app/src/main/resources/db/migration/V4__create_inventory_levels_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS inventory_levels (
+    id UUID PRIMARY KEY,
+    product_id UUID NOT NULL,
+    location_id UUID NOT NULL,
+    quantity INT NOT NULL,
+    CONSTRAINT fk_inventory_levels_product FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE,
+    CONSTRAINT fk_inventory_levels_location FOREIGN KEY (location_id) REFERENCES inventory_locations(id) ON DELETE CASCADE,
+    CONSTRAINT uq_inventory_levels_product_location UNIQUE (product_id, location_id)
+);

--- a/app/src/test/java/test/oopecommerce/utils/HibernateTestUtil.java
+++ b/app/src/test/java/test/oopecommerce/utils/HibernateTestUtil.java
@@ -30,6 +30,7 @@ public class HibernateTestUtil {
         cfg.addAnnotatedClass(com.oopecommerce.models.carts.Cart.class);
         cfg.addAnnotatedClass(com.oopecommerce.models.carts.CartLineItem.class);
         cfg.addAnnotatedClass(com.oopecommerce.models.inventory.InventoryLocation.class);
+        cfg.addAnnotatedClass(com.oopecommerce.models.inventory.InventoryLevel.class);
         cfg.addAnnotatedClass(com.oopecommerce.models.payments.Payment.class);
         return cfg.buildSessionFactory();
     }


### PR DESCRIPTION
## Summary
- implement `InventoryLevel` entity to track product quantity at a location
- add SQL migration to create `inventory_levels` table
- expose `InventoryLevelController` with list, get, set and delete endpoints
- create DTOs and repositories (in-memory and hibernate) for inventory levels and locations
- register new entities in Hibernate utilities

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_684cd828939c8330ac0a384f0838d00d