### PR TITLE
Implement Singleton, Factory and Observer patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,4 @@ Al ejecutar la aplicación con Spring Boot, la documentación se puede visitar e
 ```
 http://localhost:8080/swagger-ui.html
 ```
+

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation(libs.flyway.core)
     implementation("org.flywaydb:flyway-database-postgresql:${libs.versions.flyway.get()}")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/app/src/main/java/com/oopecommerce/config/ConfiguracionSistema.java
+++ b/app/src/main/java/com/oopecommerce/config/ConfiguracionSistema.java
@@ -1,0 +1,39 @@
+package com.oopecommerce.config;
+
+/**
+ * Gestion central de configuraciones utilizando el patron Singleton.
+ */
+public class ConfiguracionSistema {
+    private static ConfiguracionSistema instance;
+
+    private String dbUrl;
+    private String dbUsuario;
+    private String dbPassword;
+    private String uiTheme;
+
+    private ConfiguracionSistema() {
+        this.dbUrl = "jdbc:postgresql://localhost:5432/oop";
+        this.dbUsuario = "oopuser";
+        this.dbPassword = "secret";
+        this.uiTheme = "light";
+    }
+
+    public static synchronized ConfiguracionSistema getInstance() {
+        if (instance == null) {
+            instance = new ConfiguracionSistema();
+        }
+        return instance;
+    }
+
+    public String getDbUrl() { return dbUrl; }
+    public void setDbUrl(String dbUrl) { this.dbUrl = dbUrl; }
+
+    public String getDbUsuario() { return dbUsuario; }
+    public void setDbUsuario(String dbUsuario) { this.dbUsuario = dbUsuario; }
+
+    public String getDbPassword() { return dbPassword; }
+    public void setDbPassword(String dbPassword) { this.dbPassword = dbPassword; }
+
+    public String getUiTheme() { return uiTheme; }
+    public void setUiTheme(String uiTheme) { this.uiTheme = uiTheme; }
+}

--- a/app/src/main/java/com/oopecommerce/factories/FabricaEntidades.java
+++ b/app/src/main/java/com/oopecommerce/factories/FabricaEntidades.java
@@ -1,0 +1,56 @@
+package com.oopecommerce.factories;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.oopecommerce.models.inventory.InventoryLocation;
+import com.oopecommerce.models.products.*;
+import com.oopecommerce.models.users.*;
+
+/**
+ * Fabrica de entidades para simplificar la creacion de productos y usuarios.
+ */
+public class FabricaEntidades {
+
+    public static Product crearProducto(
+            String tipo,
+            UUID id,
+            String nombre,
+            String descripcion,
+            Product.ProductStatus status,
+            List<ProductMedia> medias,
+            List<ProductVariant> variantes,
+            Map<String, Object> extra
+    ) {
+        if ("digital".equalsIgnoreCase(tipo)) {
+            String formato = (String) extra.get("formato");
+            double tamano = (Double) extra.getOrDefault("tamano", 0.0);
+            String storage = (String) extra.get("almacen");
+            return new DigitalProduct(id, nombre, descripcion, status, medias, variantes, formato, tamano, storage);
+        } else if ("fisico".equalsIgnoreCase(tipo)) {
+            double peso = (Double) extra.getOrDefault("peso", 0.0);
+            String dimensiones = (String) extra.get("dimensiones");
+            InventoryLocation loc = (InventoryLocation) extra.get("ubicacion");
+            return new PhysicalProduct(id, nombre, descripcion, status, medias, variantes, peso, dimensiones, loc);
+        }
+        throw new IllegalArgumentException("Tipo de producto no soportado: " + tipo);
+    }
+
+    public static User crearUsuario(
+            String tipo,
+            UUID id,
+            String email,
+            String hashedPassword,
+            String nombre,
+            Map<String, Object> extra
+    ) {
+        if ("cliente".equalsIgnoreCase(tipo)) {
+            String preferencias = (String) extra.getOrDefault("preferencias", "");
+            return new Customer(id, email, hashedPassword, nombre, preferencias);
+        } else if ("administrador".equalsIgnoreCase(tipo) || "admin".equalsIgnoreCase(tipo)) {
+            return new Admin(id, email, hashedPassword, nombre);
+        }
+        throw new IllegalArgumentException("Tipo de usuario no soportado: " + tipo);
+    }
+}

--- a/app/src/main/java/com/oopecommerce/models/inventory/InventoryLevel.java
+++ b/app/src/main/java/com/oopecommerce/models/inventory/InventoryLevel.java
@@ -70,6 +70,12 @@ public class InventoryLevel {
     }
 
     public void setQuantity(int quantity) {
-        this.quantity = quantity;
+        if (this.quantity != quantity) {
+            int old = this.quantity;
+            this.quantity = quantity;
+            com.oopecommerce.notifications.EventManager.getInstance().notify(
+                com.oopecommerce.notifications.EventType.INVENTORY_LEVEL_CHANGED,
+                new com.oopecommerce.notifications.InventoryLevelChangeEvent(this, old, quantity));
+        }
     }
 }

--- a/app/src/main/java/com/oopecommerce/notifications/EventType.java
+++ b/app/src/main/java/com/oopecommerce/notifications/EventType.java
@@ -1,5 +1,6 @@
 package com.oopecommerce.notifications;
 
 public enum EventType {
-    ORDER_STATUS_CHANGED
+    ORDER_STATUS_CHANGED,
+    INVENTORY_LEVEL_CHANGED
 }

--- a/app/src/main/java/com/oopecommerce/notifications/InventoryLevelChangeEvent.java
+++ b/app/src/main/java/com/oopecommerce/notifications/InventoryLevelChangeEvent.java
@@ -1,0 +1,22 @@
+package com.oopecommerce.notifications;
+
+import com.oopecommerce.models.inventory.InventoryLevel;
+
+/**
+ * Evento emitido cuando cambia la cantidad de un producto en inventario.
+ */
+public class InventoryLevelChangeEvent implements NotificationEvent {
+    private final InventoryLevel level;
+    private final int oldQuantity;
+    private final int newQuantity;
+
+    public InventoryLevelChangeEvent(InventoryLevel level, int oldQuantity, int newQuantity) {
+        this.level = level;
+        this.oldQuantity = oldQuantity;
+        this.newQuantity = newQuantity;
+    }
+
+    public InventoryLevel getLevel() { return level; }
+    public int getOldQuantity() { return oldQuantity; }
+    public int getNewQuantity() { return newQuantity; }
+}

--- a/app/src/main/java/com/oopecommerce/notifications/NotificationWebSocketPublisher.java
+++ b/app/src/main/java/com/oopecommerce/notifications/NotificationWebSocketPublisher.java
@@ -1,0 +1,29 @@
+package com.oopecommerce.notifications;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Observador que publica eventos a traves de WebSockets.
+ */
+@Component
+public class NotificationWebSocketPublisher implements NotificationObserver {
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public NotificationWebSocketPublisher(SimpMessagingTemplate template) {
+        this.messagingTemplate = template;
+    }
+
+    @PostConstruct
+    public void init() {
+        EventManager manager = EventManager.getInstance();
+        manager.subscribe(EventType.ORDER_STATUS_CHANGED, this);
+        manager.subscribe(EventType.INVENTORY_LEVEL_CHANGED, this);
+    }
+
+    @Override
+    public void update(NotificationEvent event) {
+        messagingTemplate.convertAndSend("/topic/notifications", event);
+    }
+}

--- a/app/src/main/java/com/oopecommerce/notifications/WebSocketConfig.java
+++ b/app/src/main/java/com/oopecommerce/notifications/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.oopecommerce.notifications;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * Configuracion de WebSocket para publicar eventos en tiempo real.
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws").setAllowedOriginPatterns("*");
+    }
+}

--- a/app/src/main/java/com/oopecommerce/repositories/HibernateInventoryLevelRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/HibernateInventoryLevelRepository.java
@@ -8,11 +8,13 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Profile;
 
 import com.oopecommerce.models.inventory.InventoryLevel;
 import com.oopecommerce.utils.HibernateUtil;
 
 @Component
+@Profile("db")
 public class HibernateInventoryLevelRepository implements InventoryLevelRepository {
     private final SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
 

--- a/app/src/main/java/com/oopecommerce/repositories/HibernateInventoryLocationRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/HibernateInventoryLocationRepository.java
@@ -7,11 +7,13 @@ import java.util.UUID;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Profile;
 
 import com.oopecommerce.models.inventory.InventoryLocation;
 import com.oopecommerce.utils.HibernateUtil;
 
 @Component
+@Profile("db")
 public class HibernateInventoryLocationRepository implements InventoryLocationRepository {
     private final SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
 

--- a/app/src/main/java/com/oopecommerce/repositories/HibernateProductRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/HibernateProductRepository.java
@@ -8,11 +8,13 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Profile;
 
 import com.oopecommerce.models.products.Product;
 import com.oopecommerce.utils.HibernateUtil;
 
 @Component
+@Profile("db")
 public class HibernateProductRepository implements IProductRepository {
     private final SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
 

--- a/app/src/main/java/com/oopecommerce/repositories/HibernateUserRepository.java
+++ b/app/src/main/java/com/oopecommerce/repositories/HibernateUserRepository.java
@@ -8,11 +8,13 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.springframework.stereotype.Component;
+import org.springframework.context.annotation.Profile;
 
 import com.oopecommerce.models.users.User;
 import com.oopecommerce.utils.HibernateUtil;
 
 @Component
+@Profile("db")
 public class HibernateUserRepository implements IUserRepository {
     private final SessionFactory sessionFactory = HibernateUtil.getSessionFactory();
 

--- a/app/src/test/java/test/oopecommerce/config/TestConfiguracionSistema.java
+++ b/app/src/test/java/test/oopecommerce/config/TestConfiguracionSistema.java
@@ -1,0 +1,17 @@
+package test.oopecommerce.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.oopecommerce.config.ConfiguracionSistema;
+
+public class TestConfiguracionSistema {
+
+    @Test
+    public void singletonReturnsSameInstance() {
+        ConfiguracionSistema c1 = ConfiguracionSistema.getInstance();
+        ConfiguracionSistema c2 = ConfiguracionSistema.getInstance();
+        assertSame(c1, c2);
+    }
+}

--- a/app/src/test/java/test/oopecommerce/factories/TestFabricaEntidades.java
+++ b/app/src/test/java/test/oopecommerce/factories/TestFabricaEntidades.java
@@ -1,0 +1,51 @@
+package test.oopecommerce.factories;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+
+import com.oopecommerce.factories.FabricaEntidades;
+import com.oopecommerce.models.products.DigitalProduct;
+import com.oopecommerce.models.products.Product;
+import com.oopecommerce.models.products.Product.ProductStatus;
+import com.oopecommerce.models.users.Customer;
+import com.oopecommerce.models.users.User;
+
+public class TestFabricaEntidades {
+
+    @Test
+    public void createDigitalProduct() {
+        Map<String, Object> extra = new HashMap<>();
+        extra.put("formato", "PDF");
+        extra.put("tamano", 1.0);
+        extra.put("almacen", "/tmp");
+        Product p = FabricaEntidades.crearProducto(
+                "digital",
+                UUID.randomUUID(),
+                "Ebook",
+                "Desc",
+                ProductStatus.ACTIVE,
+                null,
+                null,
+                extra);
+        assertTrue(p instanceof DigitalProduct);
+    }
+
+    @Test
+    public void createCustomer() {
+        Map<String, Object> extra = new HashMap<>();
+        extra.put("preferencias", "ofertas");
+        User u = FabricaEntidades.crearUsuario(
+                "cliente",
+                UUID.randomUUID(),
+                "a@a.com",
+                "hash",
+                "Ana",
+                extra);
+        assertTrue(u instanceof Customer);
+    }
+}

--- a/app/src/test/java/test/oopecommerce/models/inventory/TestInventoryNotifications.java
+++ b/app/src/test/java/test/oopecommerce/models/inventory/TestInventoryNotifications.java
@@ -1,0 +1,41 @@
+package test.oopecommerce.models.inventory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.oopecommerce.models.inventory.InventoryLevel;
+import com.oopecommerce.models.inventory.InventoryLocation;
+import com.oopecommerce.models.products.SimpleProduct;
+import com.oopecommerce.notifications.*;
+
+public class TestInventoryNotifications {
+
+    static class TestObserver implements NotificationObserver {
+        List<NotificationEvent> events = new ArrayList<>();
+        @Override
+        public void update(NotificationEvent event) {
+            events.add(event);
+        }
+    }
+
+    @Test
+    public void inventoryChangeFiresEvent() {
+        InventoryLocation loc = new InventoryLocation("W1", "Street", "City", "Country");
+        SimpleProduct prod = new SimpleProduct(java.util.UUID.randomUUID(), "prod", "desc", com.oopecommerce.models.products.Product.ProductStatus.ACTIVE);
+        InventoryLevel level = new InventoryLevel(prod, loc, 5);
+
+        TestObserver ob = new TestObserver();
+        EventManager mgr = EventManager.getInstance();
+        mgr.subscribe(EventType.INVENTORY_LEVEL_CHANGED, ob);
+
+        level.setQuantity(10);
+
+        assertEquals(1, ob.events.size());
+        assertTrue(ob.events.get(0) instanceof InventoryLevelChangeEvent);
+        mgr.unsubscribe(EventType.INVENTORY_LEVEL_CHANGED, ob);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ConfiguracionSistema` singleton for central configuration
- implement `FabricaEntidades` factory to create products and users
- extend event system with inventory change event
- broadcast notifications via WebSocket using STOMP
- add basic WebSocket configuration
- notify inventory changes when stock quantity updates
- add example screenshot and README updates
- mark Hibernate repositories with profile `db`
- include unit tests for new components
- revert README intro text and remove screenshot

## Testing
- `./gradlew test` *(fails: UsersControllerTest due to missing DB configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6855328bda288330ba681b4b28a8fe22