### PR TITLE
Add use case diagrams

### DIFF
--- a/docs/uml/usecases/casos-de-uso-admin.puml
+++ b/docs/uml/usecases/casos-de-uso-admin.puml
@@ -1,0 +1,18 @@
+@startuml "Caso de uso - Administrador"
+left to right direction
+actor Administrador as admin
+
+rectangle "Panel de Administración" {
+    usecase "Gestionar productos" as manageProducts
+    usecase "Gestionar inventario" as manageInventory
+    usecase "Gestionar pedidos" as manageOrders
+    usecase "Gestionar usuarios" as manageUsers
+    usecase "Generar reportes" as generateReports
+}
+
+admin --> manageProducts
+admin --> manageInventory
+admin --> manageOrders
+admin --> manageUsers
+admin --> generateReports
+@enduml

--- a/docs/uml/usecases/casos-de-uso-cliente.puml
+++ b/docs/uml/usecases/casos-de-uso-cliente.puml
@@ -1,0 +1,27 @@
+@startuml "Caso de uso - Cliente"
+left to right direction
+actor Cliente as customer
+actor SistemaDePago as payment
+
+rectangle "Tienda en línea" {
+    usecase "Registrarse" as register
+    usecase "Iniciar sesión" as login
+    usecase "Buscar productos" as search
+    usecase "Ver detalle de producto" as viewProduct
+    usecase "Añadir al carrito" as addToCart
+    usecase "Actualizar carrito" as updateCart
+    usecase "Realizar checkout" as checkout
+    usecase "Seguir estado de pedido" as trackOrder
+}
+
+customer --> register
+customer --> login
+customer --> search
+customer --> viewProduct
+customer --> addToCart
+customer --> updateCart
+customer --> checkout
+customer --> trackOrder
+checkout --> payment : include
+
+@enduml


### PR DESCRIPTION
## Summary
- create use case diagram for customers
- create use case diagram for admins

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685f250ff8cc83308c4e76ca5ed368fc